### PR TITLE
edited 'should not' to 'should'

### DIFF
--- a/system-setup/linux.md
+++ b/system-setup/linux.md
@@ -16,7 +16,7 @@ _Note: This document uses the term `host` to mean your actual bare-metal Linux i
 ## Installation Instructions
 
 1. Confirm that you have a working `snapd` by running `snap help` or [install snapd](https://snapcraft.io/docs/installing-snapd)
-1. Open your terminal on your host environment and check if you have an SSH key on your system by seeing if `~/.ssh/id_rsa.pub` exists. If you do not have a key, you can generate one with `ssh-keygen -t rsa`. If you do not wish to set a password, just hit ENTER when asked for a passphrase. You should not have a public / private keyboard located at `~/.ssh/id_rsa.pub` and `~/.ssh/id_rsa` respectively.
+1. Open your terminal on your host environment and check if you have an SSH key on your system by seeing if `~/.ssh/id_rsa.pub` exists. If you do not have a key, you can generate one with `ssh-keygen -t rsa`. If you do not wish to set a password, just hit ENTER when asked for a passphrase. You should have a public / private keyboard located at `~/.ssh/id_rsa.pub` and `~/.ssh/id_rsa` respectively.
 1. Generate a YAML configuration file named `primary-config.yaml` containing your public key via the following:
 
 ```bash


### PR DESCRIPTION
I assume we "should have a public / private keyboard located at `~/.ssh/id_rsa.pub` and `~/.ssh/id_rsa` respectively."