### PR TITLE
add -e flag to Mac installation command

### DIFF
--- a/system-setup/mac.md
+++ b/system-setup/mac.md
@@ -13,7 +13,7 @@ The suggested toolkit for Mac users is Multipass, a command line tool provided b
 
 ```bash
 cd ~
-echo -n "ssh_authorized_keys:\n  - " > ~/primary-config.yaml
+echo -n -e "ssh_authorized_keys:\n  - " > ~/primary-config.yaml
 cat ~/.ssh/id_rsa.pub >> ~/primary-config.yaml
 ```
 


### PR DESCRIPTION
Encountered the same issue mentioned in PR #14 in the Mac installation guide

Echo requires -e to enable interpretation of backslash escapes (\n). If you do not add -e you get

`launch failed: operator[] call on a scalar (key: "users")`

@gparmer @bushidocodes 